### PR TITLE
not truncate process name on Mac

### DIFF
--- a/process_darwin.h
+++ b/process_darwin.h
@@ -5,9 +5,10 @@
 
 #include <errno.h>
 #include <stdlib.h>
-#include <sys/sysctl.h>
-#include <sys/proc_info.h>
+#include <stdio.h>
+#include <strings.h>
 #include <libproc.h>
+#include <unistd.h>
 
 // This is declared in process_darwin.go
 extern void go_darwin_append_proc(pid_t, pid_t, char *);
@@ -19,72 +20,41 @@ extern void go_darwin_append_proc(pid_t, pid_t, char *);
 // be possible to do this all in Go, I didn't want to go spelunking through
 // header files to get all the structures properly. It is much easier to just
 // call it in C and be done with it.
-static inline int darwinProcesses0() {
-    int err = 0;
-    int i = 0;
-    static const int name[] = { CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0 };
-    size_t length = 0;
-    struct kinfo_proc *result = NULL;
-    size_t resultCount = 0;
-
-    // Get the length first
-    err = sysctl((int*)name, (sizeof(name) / sizeof(*name)) - 1,
-            NULL, &length, NULL, 0);
-    if (err != 0) {
-        goto ERREXIT;
-    }
-
-    // Allocate the appropriate sized buffer to read the process list
-    result = malloc(length);
-
-    // Call sysctl again with our buffer to fill it with the process list
-    err = sysctl((int*)name, (sizeof(name) / sizeof(*name)) - 1,
-            result, &length,
-            NULL, 0);
-    if (err != 0) {
-        goto ERREXIT;
-    }
-
-    resultCount = length / sizeof(struct kinfo_proc);
-    for (i = 0; i < resultCount; i++) {
-        struct kinfo_proc *single = &result[i];
-        go_darwin_append_proc(
-                single->kp_proc.p_pid,
-                single->kp_eproc.e_ppid,
-                single->kp_proc.p_comm);
-    }
-
-ERREXIT:
-    if (result != NULL) {
-        free(result);
-    }
-
-    if (err != 0) {
-        return errno;
-    }
-    return 0;
-}
 
 static inline int darwinProcesses() {
 
-    int numberOfProcesses = proc_listpids(PROC_ALL_PIDS, 0, NULL, 0);
-    pid_t pids[1024];
-    bzero(pids, 1024);
-    proc_listpids(PROC_ALL_PIDS, 0, pids, sizeof(pids));
-    for (int i=0; i<numberOfProcesses; ++i) {
-        if (pids[i] == 0) { continue; }
-        char pathBuffer[PROC_PIDPATHINFO_MAXSIZE];
-        bzero(pathBuffer, PROC_PIDPATHINFO_MAXSIZE);
-        proc_pidpath(pids[i], pathBuffer, sizeof(pathBuffer));
-        if (strlen(pathBuffer) > 0) {
-            printf("path: %s\n", pathBuffer);
-            go_darwin_append_proc(
-                    pids[i],
-                    0,
-                    pathBuffer);
-        }
+  uid_t euid = geteuid();
+
+  int pid_buf_size = proc_listpids(PROC_ALL_PIDS, 0, NULL, 0);
+  int pid_count = pid_buf_size / sizeof(pid_t);
+
+  pid_t* pids = malloc(pid_buf_size);
+  bzero(pids, pid_buf_size);
+
+  proc_listpids(PROC_ALL_PIDS, 0, pids, pid_buf_size);
+  char path_buffer[PROC_PIDPATHINFO_MAXSIZE];
+
+  int ppid = 0;
+
+  for (int i=0; i < pid_count; i++) {
+    if (pids[i] == 0) break;
+
+    if (euid == 0) {
+      // You need root permission to get proc_bsdinfo from some processes.
+      // When you call following function with normal user permission you will
+      // receive 'operation not permitted' error and it will be terminated.
+      struct proc_bsdinfo bsdinfo;
+      proc_pidinfo(pids[i], PROC_PIDTBSDINFO, 0, &bsdinfo, sizeof(struct proc_bsdinfo));
+      ppid = bsdinfo.pbi_ppid;
     }
 
-    return 0;
+    bzero(path_buffer, PROC_PIDPATHINFO_MAXSIZE);
+    if (proc_pidpath(pids[i], path_buffer, sizeof(path_buffer)) > 0) {
+      go_darwin_append_proc(pids[i], ppid, path_buffer);
+    }
+  }
+  free(pids);
+
+  return 0;
 }
 #endif


### PR DESCRIPTION
process_darwin.h changed to use proc_listpids, proc_pidinfo and proc_pidpath.