### PR TITLE
Add Args() to surface arguments supplied to a process

### DIFF
--- a/process.go
+++ b/process.go
@@ -19,6 +19,10 @@ type Process interface {
 	// Executable name running this process. This is not a path to the
 	// executable.
 	Executable() string
+
+	// Args contain the arguments passed along with the executable name
+	// for this process.
+	Args() string
 }
 
 // Processes returns all processes.

--- a/process_darwin.go
+++ b/process_darwin.go
@@ -6,7 +6,9 @@ package ps
 import "C"
 
 import (
+	"strings"
 	"sync"
+	"unsafe"
 )
 
 // This lock is what verifies that C calling back into Go is only
@@ -18,7 +20,10 @@ type DarwinProcess struct {
 	pid    int
 	ppid   int
 	binary string
+	args   string
 }
+
+var _ Process = &DarwinProcess{}
 
 func (p *DarwinProcess) Pid() int {
 	return p.pid
@@ -32,12 +37,30 @@ func (p *DarwinProcess) Executable() string {
 	return p.binary
 }
 
+func (p *DarwinProcess) Args() string {
+	return p.args
+}
+
 //export go_darwin_append_proc
-func go_darwin_append_proc(pid C.pid_t, ppid C.pid_t, comm *C.char) {
+func go_darwin_append_proc(pid C.pid_t, ppid C.pid_t, comm *C.char, argc C.int, argv ***C.char) {
+	var argStr string
+
+	if int(argc) > 1 {
+		var argStrArr []string
+		cargs := (*[]*C.char)(unsafe.Pointer(argv))
+
+		for i := 1; i < int(argc); i++ {
+			argStrArr = append(argStrArr, C.GoString((*cargs)[i]))
+		}
+
+		argStr = strings.Join(argStrArr, " ")
+	}
+
 	proc := &DarwinProcess{
 		pid:    int(pid),
 		ppid:   int(ppid),
 		binary: C.GoString(comm),
+		args:   argStr,
 	}
 
 	darwinProcs = append(darwinProcs, proc)

--- a/process_darwin.h
+++ b/process_darwin.h
@@ -3,12 +3,22 @@
 #ifndef _GO_PROCESSDARWIN_H_INCLUDED
 #define _GO_PROCESSDARWIN_H_INCLUDED
 
+#include <ctype.h>
 #include <errno.h>
+#include <string.h>
 #include <stdlib.h>
 #include <sys/sysctl.h>
 
 // This is declared in process_darwin.go
-extern void go_darwin_append_proc(pid_t, pid_t, char *);
+extern void go_darwin_append_proc(pid_t, pid_t, char *, int, char ***);
+
+// This verifies if the current character under consideration is valid
+// executable or argument character or not. There are cases seen where
+// the arguments are not separated from the executable name by a NUL
+// character but instead with a whitespace.
+static inline int __isvalid(int c) {
+	return c && !isspace(c);
+}
 
 // Loads the process table and calls the exported Go function to insert
 // the data back into the Go space.
@@ -19,14 +29,15 @@ extern void go_darwin_append_proc(pid_t, pid_t, char *);
 // call it in C and be done with it.
 static inline int darwinProcesses() {
     int err = 0;
-    int i = 0;
-    static const int name[] = { CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0 };
+    int i = 0, j = 0;
+    static int name[] = { CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0 };
+    static int args[] = { CTL_KERN, 0, 0 };
     size_t length = 0;
     struct kinfo_proc *result = NULL;
     size_t resultCount = 0;
 
     // Get the length first
-    err = sysctl((int*)name, (sizeof(name) / sizeof(*name)) - 1,
+    err = sysctl(name, (sizeof(name) / sizeof(*name)) - 1,
             NULL, &length, NULL, 0);
     if (err != 0) {
         goto ERREXIT;
@@ -34,9 +45,12 @@ static inline int darwinProcesses() {
 
     // Allocate the appropriate sized buffer to read the process list
     result = malloc(length);
+    if (!result) {
+        goto ERREXIT;
+    }
 
     // Call sysctl again with our buffer to fill it with the process list
-    err = sysctl((int*)name, (sizeof(name) / sizeof(*name)) - 1,
+    err = sysctl(name, (sizeof(name) / sizeof(*name)) - 1,
             result, &length,
             NULL, 0);
     if (err != 0) {
@@ -46,10 +60,87 @@ static inline int darwinProcesses() {
     resultCount = length / sizeof(struct kinfo_proc);
     for (i = 0; i < resultCount; i++) {
         struct kinfo_proc *single = &result[i];
+        pid_t pid = single->kp_proc.p_pid;
+        char *p, *proc_argv, **argv;
+        size_t count;
+        int nargs, argmax, offset = 0;
+
+        args[1] = KERN_ARGMAX;
+
+        count = sizeof argmax;
+        err = sysctl(args, 2, &argmax, &count, NULL, 0);
+        if (err) {
+            goto ERREXIT;
+        }
+
+        proc_argv = malloc(argmax);
+        if (!proc_argv) {
+            goto ERREXIT;
+        }
+
+        args[1] = KERN_PROCARGS2;
+        args[2] = pid;
+
+        count = argmax;
+        err = sysctl(args, 3, proc_argv, &count, NULL, 0);
+        if (err) {
+            // We explicitly return if no valid arguments are found
+            // for this command.
+            if (errno == EINVAL) {
+                // Mark errno as 0, as that is the value returned from
+                // any calls made to a multi-valued cgo function.
+                errno = 0;
+
+                // No arguments were found and we inform our Go
+                // counterpart for the processing it needs to skip.
+                nargs = 0;
+
+                // No cleanup is necessary for argv as nothing was
+                // allocated for it.
+                argv = NULL;
+                goto RESULT;
+            }
+
+            goto ERREXIT;
+        }
+
+        // `proc_argv` contains the following data in order.
+        //  1. count of arguments, includes the binary.
+        //  2. complete executable path.
+        //  3. name of the binary, delimited usually by a NUL or a whitespace.
+        //  4. list of arguments, delimited usually by NUL or a whitespace.
+
+        memcpy(&nargs, proc_argv, sizeof nargs);
+        p = proc_argv + sizeof nargs;
+
+        // `argv` will contain all the arguments of the process, starting with
+        // the name of the binary.
+        argv = malloc(sizeof (char *) * nargs);
+        if (!argv) {
+            goto ERREXIT;
+        }
+
+        // Save all the arguments in the argv that will be returned to Go.
+        for (offset = 0; offset < nargs; offset++) {
+            while (__isvalid(*p)) p++;
+            while (!__isvalid(*p)) p++;
+
+            argv[offset] = p;
+        }
+
+RESULT:
         go_darwin_append_proc(
-                single->kp_proc.p_pid,
+                pid,
                 single->kp_eproc.e_ppid,
-                single->kp_proc.p_comm);
+                single->kp_proc.p_comm,
+                nargs,
+                &argv);
+
+        free(proc_argv);
+
+        if (argv != NULL) {
+            free(argv);
+        }
     }
 
 ERREXIT:

--- a/process_freebsd.go
+++ b/process_freebsd.go
@@ -125,6 +125,10 @@ func (p *UnixProcess) Executable() string {
 	return p.binary
 }
 
+func (p *UnixProcess) Args() string {
+	return ""
+}
+
 // Refresh reloads all the data associated with this process.
 func (p *UnixProcess) Refresh() error {
 

--- a/process_windows.go
+++ b/process_windows.go
@@ -57,6 +57,10 @@ func (p *WindowsProcess) Executable() string {
 	return p.exe
 }
 
+func (p *WindowsProcess) Args() string {
+	return ""
+}
+
 func newWindowsProcess(e *PROCESSENTRY32) *WindowsProcess {
 	// Find when the string ends for decoding
 	end := 0


### PR DESCRIPTION
This helps expose the command line arguments for all processes running on a given machine. This functionality is currently supported only on Linux and OSX.
