### PR TITLE
Add FilterProcesses 

### DIFF
--- a/process.go
+++ b/process.go
@@ -28,7 +28,12 @@ type Process interface {
 // process table, in which case the process table returned might contain
 // ephemeral entities that happened to be running when this was called.
 func Processes() ([]Process, error) {
-	return processes()
+	return processes(nil)
+}
+
+// FilterProcesses returns processes that satisfy the predicate f.
+func FilterProcesses(f func(Process) bool) ([]Process, error) {
+	return processes(f)
 }
 
 // FindProcess looks up a single process by pid.

--- a/process_freebsd.go
+++ b/process_freebsd.go
@@ -172,7 +172,7 @@ func findProcess(pid int) (Process, error) {
 	return newUnixProcess(pid)
 }
 
-func processes() ([]Process, error) {
+func processes(f func(Process) bool) ([]Process, error) {
 	results := make([]Process, 0, 50)
 
 	mib := []int32{CTL_KERN, KERN_PROC, KERN_PROC_PROC, 0}
@@ -198,6 +198,9 @@ func processes() ([]Process, error) {
 			continue
 		}
 		p.ppid, p.pgrp, p.sid, p.binary = copy_params(&k)
+		if f != nil && !f(p) {
+			continue
+		}
 
 		results = append(results, p)
 	}

--- a/process_test.go
+++ b/process_test.go
@@ -2,6 +2,7 @@ package ps
 
 import (
 	"os"
+	"os/exec"
 	"testing"
 )
 
@@ -42,4 +43,35 @@ func TestProcesses(t *testing.T) {
 	if !found {
 		t.Fatal("should have Go")
 	}
+}
+
+func TestFilterProcesses(t *testing.T) {
+	// should have go
+	cmd := exec.Command("go")
+	err := cmd.Start()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	// Return true only if p is the process started by cmd.Start()
+	f := func(p Process) bool {
+		pid := os.Getpid()
+		if p.PPid() == pid {
+			return true
+		}
+		return false
+	}
+	p, err := FilterProcesses(f)
+	_ = cmd.Wait()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if len(p) != 1 {
+		t.Fatal("should have one go processe")
+	}
+
+	if p[0].Executable() != "go" && p[0].Executable() != "go.exe" {
+		t.Fatal("should have one go processe")
+	}
+
 }

--- a/process_unix.go
+++ b/process_unix.go
@@ -75,7 +75,7 @@ func findProcess(pid int) (Process, error) {
 	return newUnixProcess(pid)
 }
 
-func processes() ([]Process, error) {
+func processes(f func(Process) bool) ([]Process, error) {
 	d, err := os.Open("/proc")
 	if err != nil {
 		return nil, err
@@ -113,6 +113,10 @@ func processes() ([]Process, error) {
 
 			p, err := newUnixProcess(int(pid))
 			if err != nil {
+				continue
+			}
+
+			if f != nil && !f(p) {
 				continue
 			}
 


### PR DESCRIPTION
This PR enables users to retrieve not only all processes but filtered one with a user defined predicate,
also should solve issues filed at #18 and #4 in more generic way.

Additionally this would get FindProcess more (cpu|memory) efficient than the current on (windows|darwin),
since those platforms have used processes() internally which cause listing all processes.

Tested on every platform with the latest build.