### PR TITLE
Add ActiveProcess to get active window process

### DIFF
--- a/process.go
+++ b/process.go
@@ -38,3 +38,11 @@ func Processes() ([]Process, error) {
 func FindProcess(pid int) (Process, error) {
 	return findProcess(pid)
 }
+
+// ActiveProcess looks up a single process by current active window.
+//
+// Process will be nil and error will be nil if a matching process is
+// not found.
+func ActiveProcess() (Process, error) {
+	return activeProcess()
+}


### PR DESCRIPTION
The method get the process from the active window. There are similar methods in the DLL but have some restrictions, using the snapshot bypass it.

Unfortunately had to load `user32.dll` to get the active window.