### PR TITLE
Add solaris support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 go-ps is a library for Go that implements OS-specific APIs to list and
 manipulate processes in a platform-safe way. The library can find and
-list processes on Linux, Mac OS X, and Windows.
+list processes on Linux, Mac OS X, Solaris, and Windows.
 
 If you're new to Go, this library has a good amount of advanced Go educational
 value as well. It uses some advanced features of Go: build tags, accessing

--- a/process_linux.go
+++ b/process_linux.go
@@ -1,0 +1,35 @@
+// +build linux
+
+package ps
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// Refresh reloads all the data associated with this process.
+func (p *UnixProcess) Refresh() error {
+	statPath := fmt.Sprintf("/proc/%d/stat", p.pid)
+	dataBytes, err := ioutil.ReadFile(statPath)
+	if err != nil {
+		return err
+	}
+
+	// First, parse out the image name
+	data := string(dataBytes)
+	binStart := strings.IndexRune(data, '(') + 1
+	binEnd := strings.IndexRune(data[binStart:], ')')
+	p.binary = data[binStart : binStart+binEnd]
+
+	// Move past the image name and start parsing the rest
+	data = data[binStart+binEnd+2:]
+	_, err = fmt.Sscanf(data,
+		"%c %d %d %d",
+		&p.state,
+		&p.ppid,
+		&p.pgrp,
+		&p.sid)
+
+	return err
+}

--- a/process_solaris.go
+++ b/process_solaris.go
@@ -1,0 +1,34 @@
+// +build solaris
+
+package ps
+
+// #include <fcntl.h>
+// #include <procfs.h>
+//
+// int read_psinfo(const char *path, psinfo_t *psi) {
+//   int fh;
+//   int retval = 0;
+//   if ((fh = open(path, O_RDONLY)) >= 0) {
+//     if (read(fh, psi, sizeof(psinfo_t)) == -1) {
+//       retval = 1;
+//     }
+//     close(fh);
+//     return retval;
+//   }
+//   return 2;
+// }
+import "C"
+
+import "fmt"
+
+func (p *UnixProcess) Refresh() error {
+	var psinfo C.psinfo_t
+	path := fmt.Sprintf("/proc/%d/psinfo", p.pid)
+	_, err := C.read_psinfo(C.CString(path), &psinfo)
+	if err != nil {
+		return err
+	}
+	p.ppid = int(psinfo.pr_ppid)
+	p.binary = C.GoString(&psinfo.pr_fname[0])
+	return nil
+}

--- a/process_solaris.go
+++ b/process_solaris.go
@@ -2,33 +2,95 @@
 
 package ps
 
-// #include <fcntl.h>
-// #include <procfs.h>
-//
-// int read_psinfo(const char *path, psinfo_t *psi) {
-//   int fh;
-//   int retval = 0;
-//   if ((fh = open(path, O_RDONLY)) >= 0) {
-//     if (read(fh, psi, sizeof(psinfo_t)) == -1) {
-//       retval = 1;
-//     }
-//     close(fh);
-//     return retval;
-//   }
-//   return 2;
-// }
-import "C"
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+)
 
-import "fmt"
+type ushort_t uint16
+
+type id_t int32
+type pid_t int32
+type uid_t int32
+type gid_t int32
+
+type dev_t uint64
+type size_t uint64
+type uintptr_t uint64
+
+type timestruc_t [16]byte
+
+// This is copy from /usr/include/sys/procfs.h
+type psinfo_t struct {
+	Pr_flag   int32     /* process flags (DEPRECATED; do not use) */
+	Pr_nlwp   int32     /* number of active lwps in the process */
+	Pr_pid    pid_t     /* unique process id */
+	Pr_ppid   pid_t     /* process id of parent */
+	Pr_pgid   pid_t     /* pid of process group leader */
+	Pr_sid    pid_t     /* session id */
+	Pr_uid    uid_t     /* real user id */
+	Pr_euid   uid_t     /* effective user id */
+	Pr_gid    gid_t     /* real group id */
+	Pr_egid   gid_t     /* effective group id */
+	Pr_addr   uintptr_t /* address of process */
+	Pr_size   size_t    /* size of process image in Kbytes */
+	Pr_rssize size_t    /* resident set size in Kbytes */
+	Pr_pad1   size_t
+	Pr_ttydev dev_t /* controlling tty device (or PRNODEV) */
+
+	// Guess this following 2 ushort_t values require a padding to properly
+	// align to the 64bit mark.
+	Pr_pctcpu   ushort_t /* % of recent cpu time used by all lwps */
+	Pr_pctmem   ushort_t /* % of system memory used by process */
+	Pr_pad64bit [4]byte
+
+	Pr_start    timestruc_t /* process start time, from the epoch */
+	Pr_time     timestruc_t /* usr+sys cpu time for this process */
+	Pr_ctime    timestruc_t /* usr+sys cpu time for reaped children */
+	Pr_fname    [16]byte    /* name of execed file */
+	Pr_psargs   [80]byte    /* initial characters of arg list */
+	Pr_wstat    int32       /* if zombie, the wait() status */
+	Pr_argc     int32       /* initial argument count */
+	Pr_argv     uintptr_t   /* address of initial argument vector */
+	Pr_envp     uintptr_t   /* address of initial environment vector */
+	Pr_dmodel   [1]byte     /* data model of the process */
+	Pr_pad2     [3]byte
+	Pr_taskid   id_t      /* task id */
+	Pr_projid   id_t      /* project id */
+	Pr_nzomb    int32     /* number of zombie lwps in the process */
+	Pr_poolid   id_t      /* pool id */
+	Pr_zoneid   id_t      /* zone id */
+	Pr_contract id_t      /* process contract */
+	Pr_filler   int32     /* reserved for future use */
+	Pr_lwp      [128]byte /* information for representative lwp */
+}
 
 func (p *UnixProcess) Refresh() error {
-	var psinfo C.psinfo_t
+	var psinfo psinfo_t
+
 	path := fmt.Sprintf("/proc/%d/psinfo", p.pid)
-	_, err := C.read_psinfo(C.CString(path), &psinfo)
+	fh, err := os.Open(path)
 	if err != nil {
 		return err
 	}
-	p.ppid = int(psinfo.pr_ppid)
-	p.binary = C.GoString(&psinfo.pr_fname[0])
+	defer fh.Close()
+
+	err = binary.Read(fh, binary.LittleEndian, &psinfo)
+	if err != nil {
+		return err
+	}
+
+	p.ppid = int(psinfo.Pr_ppid)
+	p.binary = toString(psinfo.Pr_fname[:], 16)
 	return nil
+}
+
+func toString(array []byte, len int) string {
+	for i := 0; i < len; i++ {
+		if array[i] == 0 {
+			return string(array[:i])
+		}
+	}
+	return string(array[:])
 }

--- a/process_unix.go
+++ b/process_unix.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux solaris
 
 package ps
 

--- a/process_unix.go
+++ b/process_unix.go
@@ -5,10 +5,8 @@ package ps
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
-	"strings"
 )
 
 // UnixProcess is an implementation of Process that contains Unix-specific
@@ -33,32 +31,6 @@ func (p *UnixProcess) PPid() int {
 
 func (p *UnixProcess) Executable() string {
 	return p.binary
-}
-
-// Refresh reloads all the data associated with this process.
-func (p *UnixProcess) Refresh() error {
-	statPath := fmt.Sprintf("/proc/%d/stat", p.pid)
-	dataBytes, err := ioutil.ReadFile(statPath)
-	if err != nil {
-		return err
-	}
-
-	// First, parse out the image name
-	data := string(dataBytes)
-	binStart := strings.IndexRune(data, '(') + 1
-	binEnd := strings.IndexRune(data[binStart:], ')')
-	p.binary = data[binStart : binStart+binEnd]
-
-	// Move past the image name and start parsing the rest
-	data = data[binStart+binEnd+2:]
-	_, err = fmt.Sscanf(data,
-		"%c %d %d %d",
-		&p.state,
-		&p.ppid,
-		&p.pgrp,
-		&p.sid)
-
-	return err
 }
 
 func findProcess(pid int) (Process, error) {

--- a/process_unix_test.go
+++ b/process_unix_test.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux solaris
 
 package ps
 


### PR DESCRIPTION
As solaris has a `/proc` this is pretty similar to linux. Restructured the code a little, so that only UnixProcess' Refresh method had to be implemented.

The assumption is that `Executable()` returns only the name of the binary started. On solaris this is truncated to 16 characters.