### PR TITLE
Fix parse out the image name

### DIFF
--- a/process_linux.go
+++ b/process_linux.go
@@ -19,7 +19,7 @@ func (p *UnixProcess) Refresh() error {
 	// First, parse out the image name
 	data := string(dataBytes)
 	binStart := strings.IndexRune(data, '(') + 1
-	binEnd := strings.IndexRune(data[binStart:], ')')
+	binEnd := strings.IndexRune(data[binStart:], ' ') - 1
 	p.binary = data[binStart : binStart+binEnd]
 
 	// Move past the image name and start parsing the rest


### PR DESCRIPTION
ex. `((sd-pam))` on Ubuntu xenial

```
$ cat /proc/1821/stat
1821 ((sd-pam)) S 1819 1819 1819 0 -1 ...
```