### PR TITLE
Do not lstat each entry in /proc - simple numeric name check should suffice

### DIFF
--- a/process_unix.go
+++ b/process_unix.go
@@ -56,7 +56,7 @@ func processes() ([]Process, error) {
 
 	results := make([]Process, 0, 50)
 	for {
-		fis, err := d.Readdir(10)
+		names, err := d.Readdirnames(10)
 		if err == io.EOF {
 			break
 		}
@@ -64,14 +64,8 @@ func processes() ([]Process, error) {
 			return nil, err
 		}
 
-		for _, fi := range fis {
-			// We only care about directories, since all pids are dirs
-			if !fi.IsDir() {
-				continue
-			}
-
+		for _, name := range names {
 			// We only care if the name starts with a numeric
-			name := fi.Name()
 			if name[0] < '0' || name[0] > '9' {
 				continue
 			}


### PR DESCRIPTION
It is not mandatory to verify whether the file in `/proc` is a directory - simple numeric name check should suffice. Otherwise, it is pretty problematic to query processes on systems with `SELinux` in enforcing mode as it is complicated to open access to **all** files inside `/proc`.
The reason this catch-all access is required is that with `os.Readdir` it needs to `lstat` each entry to return `os.FileInfo` and this requires additional permissions on each disparate file type inside `/proc` which is not easy to catch with an attribute (as it is with just the processes).