### PR TITLE
support non-default mount point for /proc filsystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant/
+.idea/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ DLL methods for Windows, cgo for Darwin, etc.
 How it works:
 
   * **Darwin** uses the `sysctl` syscall to retrieve the process table.
-  * **Unix** uses the procfs at `/proc` to inspect the process tree.
+  * **Unix** uses the procfs at `/proc` (can be redefined by `HOST_PROC` env. var) to inspect the process
   * **Windows** uses the Windows API, and methods such as
     `CreateToolhelp32Snapshot` to get a point-in-time snapshot of
     the process table.

--- a/process_linux.go
+++ b/process_linux.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strings"
+
 )
 
 // Refresh reloads all the data associated with this process.
 func (p *UnixProcess) Refresh() error {
-	statPath := fmt.Sprintf("/proc/%d/stat", p.pid)
+	statPath := fmt.Sprintf("%s/%d/stat",GetEnv("HOST_PROC","/proc"), p.pid)
 	dataBytes, err := ioutil.ReadFile(statPath)
 	if err != nil {
 		return err

--- a/process_solaris.go
+++ b/process_solaris.go
@@ -69,7 +69,8 @@ type psinfo_t struct {
 func (p *UnixProcess) Refresh() error {
 	var psinfo psinfo_t
 
-	path := fmt.Sprintf("/proc/%d/psinfo", p.pid)
+	path := fmt.Sprintf("%s/%d/psinfo",GetEnv("HOST_PROC","/proc"), p.pid)
+
 	fh, err := os.Open(path)
 	if err != nil {
 		return err

--- a/process_unix.go
+++ b/process_unix.go
@@ -34,7 +34,7 @@ func (p *UnixProcess) Executable() string {
 }
 
 func findProcess(pid int) (Process, error) {
-	dir := fmt.Sprintf("/proc/%d", pid)
+	dir := fmt.Sprintf("%s/%d",GetEnv("HOST_PROC","/proc"), pid)
 	_, err := os.Stat(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -48,7 +48,7 @@ func findProcess(pid int) (Process, error) {
 }
 
 func processes() ([]Process, error) {
-	d, err := os.Open("/proc")
+	d, err := os.Open(GetEnv("HOST_PROC","/proc"))
 	if err != nil {
 		return nil, err
 	}

--- a/uxutils.go
+++ b/uxutils.go
@@ -1,0 +1,12 @@
+package ps
+
+import  "os"
+
+func GetEnv(key, defaultValue string) string {
+
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return defaultValue
+	}
+	return value
+}


### PR DESCRIPTION
Hello, this small extension is for support of non default mount point for /proc filesystem. The use-case here is when running in container and need to track process on a host (host `/proc` filesystem is mounted inside container into `/<some_folder>/proc`).