### PR TITLE
Avoid heavy calls when reading /proc

### DIFF
--- a/process_unix.go
+++ b/process_unix.go
@@ -56,7 +56,7 @@ func processes() ([]Process, error) {
 
 	results := make([]Process, 0, 50)
 	for {
-		fis, err := d.Readdir(10)
+		names, err := d.Readdirnames(10)
 		if err == io.EOF {
 			break
 		}
@@ -64,14 +64,8 @@ func processes() ([]Process, error) {
 			return nil, err
 		}
 
-		for _, fi := range fis {
-			// We only care about directories, since all pids are dirs
-			if !fi.IsDir() {
-				continue
-			}
-
+		for _, name := range names {
 			// We only care if the name starts with a numeric
-			name := fi.Name()
 			if name[0] < '0' || name[0] > '9' {
 				continue
 			}


### PR DESCRIPTION
On systems with SELinux in enforcing mode, this will unnecessarily require broader access to the whole of /proc (`newfstatat` or `lstat` which translated to SELinux `getattr` permission as opposed to a simple `getdents64` syscall which is less pervasive).
Reading just the names is enough though to determine whether an entry looks like a pid directory.