### PR TITLE
If the process cannot be found, it is better to return an error.

### DIFF
--- a/process.go
+++ b/process.go
@@ -33,7 +33,7 @@ func Processes() ([]Process, error) {
 
 // FindProcess looks up a single process by pid.
 //
-// Process will be nil and error will be nil if a matching process is
+// Process will be nil and error will be os.ErrNotExist if a matching process is
 // not found.
 func FindProcess(pid int) (Process, error) {
 	return findProcess(pid)

--- a/process_unix.go
+++ b/process_unix.go
@@ -37,10 +37,9 @@ func findProcess(pid int) (Process, error) {
 	dir := fmt.Sprintf("/proc/%d", pid)
 	_, err := os.Stat(dir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-
+	//	if os.IsNotExist(err) {
+	//		return nil, nil
+	//	}
 		return nil, err
 	}
 


### PR DESCRIPTION
If the process cannot be found, it is better to return an error.
