### PR TITLE
AddingPowerSupport_&_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch:
+  - amd64
+  - ppc64le
+  
 language: go
 
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ arch:
 language: go
 
 go:
-  - 1.2.1
+  - 1.13


### PR DESCRIPTION
Adding Power Support.

Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/go-ps

Please let me know if you need any further details? or if I am missing any.

Thank You !!