### PR TITLE
Add netbsd support via mount_procfs(8)

### DIFF
--- a/process_netbsd.go
+++ b/process_netbsd.go
@@ -1,0 +1,35 @@
+// +build netbsd
+
+package ps
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// Refresh reloads all the data associated with this process.
+func (p *UnixProcess) Refresh() error {
+	statPath := fmt.Sprintf("/proc/%d/stat", p.pid)
+	dataBytes, err := ioutil.ReadFile(statPath)
+	if err != nil {
+		return err
+	}
+
+	// First, parse out the image name
+	data := string(dataBytes)
+	binStart := strings.IndexRune(data, '(') + 1
+	binEnd := strings.IndexRune(data[binStart:], ')')
+	p.binary = data[binStart : binStart+binEnd]
+
+	// Move past the image name and start parsing the rest
+	data = data[binStart+binEnd+2:]
+	_, err = fmt.Sscanf(data,
+		"%c %d %d %d",
+		&p.state,
+		&p.ppid,
+		&p.pgrp,
+		&p.sid)
+
+	return err
+}

--- a/process_unix.go
+++ b/process_unix.go
@@ -1,4 +1,4 @@
-// +build linux solaris
+// +build linux netbsd solaris
 
 package ps
 

--- a/process_unix_test.go
+++ b/process_unix_test.go
@@ -1,4 +1,4 @@
-// +build linux solaris
+// +build linux netbsd solaris
 
 package ps
 


### PR DESCRIPTION
This PR adds NetBSD support via [mount_procfs(8)](https://man.netbsd.org/mount_procfs.8).

Completely based on Linux one.

(It would be probably better to avoid `mount_procfs(8)` because on some setup it can be not present (i.e. `procfs` is optional) but that's a possible starting point in order to make `go-ps` working on NetBSD too!)
